### PR TITLE
PHP 7.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 matrix:
   fast_finish: true

--- a/lib/Horde/Text/Filter/Emails.php
+++ b/lib/Horde/Text/Filter/Emails.php
@@ -61,7 +61,7 @@ class Horde_Text_Filter_Emails extends Horde_Text_Filter_Base
             ((?(1)\s*\]))
         |
             # Version 2 Pattern 9 and 10: simple email addresses.
-            (^|\s|&lt;|<|\[)([\w-+.=]+@[-A-Z0-9.]*[A-Z0-9])
+            (^|\s|&lt;|<|\[)([\w\-+.=]+@[-A-Z0-9.]*[A-Z0-9])
             # Pattern 11 to 13: Optional parameters
             ((\?)([^\s"<]*[\w+#?\/&=]))?
             # Pattern 14: Optional closing bracket

--- a/lib/Horde/Text/Filter/Linkurls.php
+++ b/lib/Horde/Text/Filter/Linkurls.php
@@ -86,7 +86,7 @@ class Horde_Text_Filter_Linkurls extends Horde_Text_Filter_Base
 (?:\b|^)
 (  # Capture 1: entire matched URL
   (
-   (?:[a-z][\w-+]{0,19})?:/{1,3}  # URL protocol and colon followed by 1-3
+   (?:[a-z][\w\-+]{0,19})?:/{1,3}  # URL protocol and colon followed by 1-3
                                   # slashes, or just colon and slashes (://)
     |                             #  - or -
     (?<!\.)www\d{0,3}\.           # "www.", "www1.", "www2." … "www999."


### PR DESCRIPTION
From Fedora QA
https://apps.fedoraproject.org/koschei/package/php-horde-Horde-Text-Filter?collection=f30

```
preg_replace_callback(): Compilation failed: invalid range in character class at offset 649
/builddir/build/BUILD/php-horde-Horde-Text-Filter-2.3.5/Horde_Text_Filter-2.3.5/lib/Horde/Text/Filter.php:99
/builddir/build/BUILD/php-horde-Horde-Text-Filter-2.3.5/Horde_Text_Filter-2.3.5/test/Horde/Text/Filter/EmailsTest.php:22

```
and 

```
preg_replace_callback(): Compilation failed: invalid range in character class at offset 68
/builddir/build/BUILD/php-horde-Horde-Text-Filter-2.3.5/Horde_Text_Filter-2.3.5/lib/Horde/Text/Filter.php:99
/builddir/build/BUILD/php-horde-Horde-Text-Filter-2.3.5/Horde_Text_Filter-2.3.5/test/Horde/Text/Filter/LinkurlsTest.php:19
20) Horde_Text_Filter_LinkurlsTest::testLinkurls with data set #7 ('://foo.com/blah_blah/', '<a href="://foo.com/blah_blah...h/</a>')

```