### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Text/Filter.php
+++ b/lib/Horde/Text/Filter.php
@@ -97,7 +97,7 @@ class Horde_Text_Filter
             if (isset($patterns['regexp_callback'])) {
                 foreach ($patterns['regexp_callback'] as $key => $val) {
                     $new_text = preg_replace_callback($key, $val, $text);
-                    if (strlen($new_text) ||
+                    if (strlen(is_null($new_text) ? "" : $new_text) ||
                         (preg_last_error() != PREG_BACKTRACK_LIMIT_ERROR)) {
                         $text = $new_text;
                     }

--- a/lib/Horde/Text/Filter/Linkurls.php
+++ b/lib/Horde/Text/Filter/Linkurls.php
@@ -155,7 +155,9 @@ END_OF_REGEX;
 
         $decoded = $orig_href;
         try {
-            if (strlen($host = $this->_parseurl($orig_href, PHP_URL_HOST))) {
+            $host = $this->_parseurl($orig_href, PHP_URL_HOST);
+            $host = is_null($host) ? "" : $host;
+            if (strlen($host)) {
                 $decoded = substr_replace(
                     $orig_href,
                     Horde_Idna::decode($host),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Text/Filter/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Text/Filter/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Text_Filter Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Text/Filter/EmailsTest.php
+++ b/test/Horde/Text/Filter/EmailsTest.php
@@ -9,7 +9,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_EmailsTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_EmailsTest extends Horde_Test_Case
 {
     /**
      * @dataProvider emailsProvider

--- a/test/Horde/Text/Filter/EnvironmentTest.php
+++ b/test/Horde/Text/Filter/EnvironmentTest.php
@@ -9,9 +9,9 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_EnvironmentTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_EnvironmentTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         putenv('COMMENT=comment');
         putenv('FOO=bar');

--- a/test/Horde/Text/Filter/Html2textTest.php
+++ b/test/Horde/Text/Filter/Html2textTest.php
@@ -9,7 +9,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_Html2textTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_Html2textTest extends Horde_Test_Case
 {
     /**
      * @dataProvider html2textProvider

--- a/test/Horde/Text/Filter/MsofficeTest.php
+++ b/test/Horde/Text/Filter/MsofficeTest.php
@@ -8,7 +8,7 @@
  * @package    Text_Filter
  * @subpackage UnitTests
  */
-class Horde_Text_Filter_Msoffice_Test extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_Msoffice_Test extends Horde_Test_Case
 {
     public function testMsoNormalCss()
     {

--- a/test/Horde/Text/Filter/SimplemarkupTest.php
+++ b/test/Horde/Text/Filter/SimplemarkupTest.php
@@ -22,7 +22,7 @@
  * @package    Text_Filter
  * @subpackage UnitTests
  */
-class Horde_Text_Filter_SimplemarkupTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_SimplemarkupTest extends Horde_Test_Case
 {
     /**
      * @dataProvider markupExamples

--- a/test/Horde/Text/Filter/Space2htmlTest.php
+++ b/test/Horde/Text/Filter/Space2htmlTest.php
@@ -9,7 +9,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_Space2htmlTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_Space2htmlTest extends Horde_Test_Case
 {
     /**
      * @dataProvider space2htmlProvider

--- a/test/Horde/Text/Filter/Text2htmlTest.php
+++ b/test/Horde/Text/Filter/Text2htmlTest.php
@@ -9,7 +9,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_Text2htmlTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_Text2htmlTest extends Horde_Test_Case
 {
     /**
      * @dataProvider text2htmlProvider

--- a/test/Horde/Text/Filter/WordsTest.php
+++ b/test/Horde/Text/Filter/WordsTest.php
@@ -22,11 +22,11 @@
  * @package    Text_Filter
  * @subpackage UnitTests
  */
-class Horde_Text_Filter_WordsTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_WordsTest extends Horde_Test_Case
 {
     private $words;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->words = array('foo', 'bar');
     }

--- a/test/Horde/Text/Filter/XssTest.php
+++ b/test/Horde/Text/Filter/XssTest.php
@@ -9,7 +9,7 @@
  * @subpackage UnitTests
  */
 
-class Horde_Text_Filter_XssTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Filter_XssTest extends Horde_Test_Case
 {
     /**
      * Test cases from http://ha.ckers.org/xss.html

--- a/test/Horde/Text/Filter/phpunit.xml
+++ b/test/Horde/Text/Filter/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-text-filter/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch#
- Debian changes: Add 1011_php8.1.patch. https://salsa.debian.org/horde-team/php-horde-text-filter/-/blob/debian-sid/debian/patches/1011_php8.1.patch
